### PR TITLE
URL state로 위치 이동

### DIFF
--- a/final-pjt-front/src/components/ReviewCreate.vue
+++ b/final-pjt-front/src/components/ReviewCreate.vue
@@ -11,7 +11,6 @@
 
 <script>
 import axios from 'axios'
-const API_URL = 'http://127.0.0.1:8000'
 
 export default {
   name: 'ReviewCreate',
@@ -30,7 +29,7 @@ export default {
       }
       axios({
         method: 'post',
-        url: `${API_URL}/api/v2/movies/118/reviews/`,
+        url: `${this.$store.state.API_URL}/api/v2/movies/118/reviews/`,
         data: {
           content: content,
           score:0,

--- a/final-pjt-front/src/store/index.js
+++ b/final-pjt-front/src/store/index.js
@@ -6,7 +6,6 @@ import router from '@/router'
 
 Vue.use(Vuex)
 
-const API_URL = 'http://127.0.0.1:8000'
 
 export default new Vuex.Store({
   plugins: [
@@ -15,6 +14,7 @@ export default new Vuex.Store({
   state: {
     movies: [],
     token: null,
+    API_URL:'http://127.0.0.1:8000'
   },
   getters: {
     isLogin(state) {
@@ -35,7 +35,7 @@ export default new Vuex.Store({
     getMovies(context) {
       axios({
         method: 'get',
-        url: `${API_URL}/api/v1/movies/`,
+        url: `${context.state.API_URL}/api/v1/movies/`,
         headers: {
           Authorization: `Token ${context.state.token}`
         }


### PR DESCRIPTION
`API_URL`의 다량의 중복 사용으로, `store.state`로 위치를 옮겼습니다.